### PR TITLE
feat: export type helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { CamelCase, JoinByCase, PascalCase, SplitByCase } from "./types";
+import type {
+  CamelCase,
+  KebabCase,
+  PascalCase,
+  SnakeCase,
+  SplitByCase,
+} from "./types";
 
 const NUMBER_CHAR_RE = /\d/;
 const STR_SPLITTERS = ["-", "_", "/", "."] as const;
@@ -103,11 +109,6 @@ export function camelCase<T extends string | readonly string[]>(string_?: T) {
   return lowerFirst(pascalCase(string_ || "")) as CamelCase<T>;
 }
 
-export type KebabCase<T extends string | readonly string[]> = JoinByCase<
-  T,
-  "-"
->;
-
 export function kebabCase(): "";
 export function kebabCase<T extends string | readonly string[]>(
   string_: T
@@ -115,7 +116,7 @@ export function kebabCase<T extends string | readonly string[]>(
 export function kebabCase<
   T extends string | readonly string[],
   Joiner extends string
->(string_: T, joiner: Joiner): JoinByCase<T, Joiner>;
+>(string_: T, joiner: Joiner): KebabCase<T, Joiner>;
 export function kebabCase<
   T extends string | readonly string[],
   Joiner extends string
@@ -124,13 +125,8 @@ export function kebabCase<
     ? ""
     : ((Array.isArray(string_) ? string_ : splitByCase(string_ as string))
         .map((p) => p.toLowerCase())
-        .join(joiner ?? "-") as JoinByCase<T, Joiner>);
+        .join(joiner ?? "-") as KebabCase<T, Joiner>);
 }
-
-export type SnakeCase<T extends string | readonly string[]> = JoinByCase<
-  T,
-  "_"
->;
 
 export function snakeCase(): "";
 export function snakeCase<T extends string | readonly string[]>(
@@ -140,9 +136,4 @@ export function snakeCase<T extends string | readonly string[]>(string_?: T) {
   return kebabCase(string_ || "", "_") as SnakeCase<T>;
 }
 
-export {
-  type CamelCase,
-  type JoinByCase,
-  type PascalCase,
-  type SplitByCase,
-} from "./types";
+export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { CamelCase, JoinByCase, PascalCase, SplitByCase } from "./types";
 
-export type { CamelCase, JoinByCase, PascalCase, SplitByCase };
-
 const NUMBER_CHAR_RE = /\d/;
 const STR_SPLITTERS = ["-", "_", "/", "."] as const;
 
@@ -105,7 +103,10 @@ export function camelCase<T extends string | readonly string[]>(string_?: T) {
   return lowerFirst(pascalCase(string_ || "")) as CamelCase<T>;
 }
 
-export type KebabCase<T extends string | readonly string[]> = JoinByCase<T, "-">
+export type KebabCase<T extends string | readonly string[]> = JoinByCase<
+  T,
+  "-"
+>;
 
 export function kebabCase(): "";
 export function kebabCase<T extends string | readonly string[]>(
@@ -126,7 +127,10 @@ export function kebabCase<
         .join(joiner ?? "-") as JoinByCase<T, Joiner>);
 }
 
-export type SnakeCase<T extends string | readonly string[]> = JoinByCase<T, "_">
+export type SnakeCase<T extends string | readonly string[]> = JoinByCase<
+  T,
+  "_"
+>;
 
 export function snakeCase(): "";
 export function snakeCase<T extends string | readonly string[]>(
@@ -135,3 +139,10 @@ export function snakeCase<T extends string | readonly string[]>(
 export function snakeCase<T extends string | readonly string[]>(string_?: T) {
   return kebabCase(string_ || "", "_") as SnakeCase<T>;
 }
+
+export {
+  type CamelCase,
+  type JoinByCase,
+  type PascalCase,
+  type SplitByCase,
+} from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,11 @@ export function isUppercase(char = ""): boolean | undefined {
 export function splitByCase<T extends string>(string_: T): SplitByCase<T>;
 export function splitByCase<
   T extends string,
-  Separator extends readonly string[]
+  Separator extends readonly string[],
 >(string_: T, separators: Separator): SplitByCase<T, Separator[number]>;
 export function splitByCase<
   T extends string,
-  Separator extends readonly string[]
+  Separator extends readonly string[],
 >(string_: T, separators?: Separator) {
   const splitters = separators ?? STR_SPLITTERS;
   const parts: string[] = [];
@@ -91,7 +91,7 @@ export function lowerFirst<S extends string>(string_: S): Uncapitalize<S> {
 
 export function pascalCase(): "";
 export function pascalCase<T extends string | readonly string[]>(
-  string_: T
+  string_: T,
 ): PascalCase<T>;
 export function pascalCase<T extends string | readonly string[]>(string_?: T) {
   return string_
@@ -103,7 +103,7 @@ export function pascalCase<T extends string | readonly string[]>(string_?: T) {
 
 export function camelCase(): "";
 export function camelCase<T extends string | readonly string[]>(
-  string_: T
+  string_: T,
 ): CamelCase<T>;
 export function camelCase<T extends string | readonly string[]>(string_?: T) {
   return lowerFirst(pascalCase(string_ || "")) as CamelCase<T>;
@@ -111,15 +111,15 @@ export function camelCase<T extends string | readonly string[]>(string_?: T) {
 
 export function kebabCase(): "";
 export function kebabCase<T extends string | readonly string[]>(
-  string_: T
+  string_: T,
 ): KebabCase<T>;
 export function kebabCase<
   T extends string | readonly string[],
-  Joiner extends string
+  Joiner extends string,
 >(string_: T, joiner: Joiner): KebabCase<T, Joiner>;
 export function kebabCase<
   T extends string | readonly string[],
-  Joiner extends string
+  Joiner extends string,
 >(string_?: T, joiner?: Joiner) {
   return string_
     ? ((Array.isArray(string_) ? string_ : splitByCase(string_ as string))
@@ -130,7 +130,7 @@ export function kebabCase<
 
 export function snakeCase(): "";
 export function snakeCase<T extends string | readonly string[]>(
-  string_: T
+  string_: T,
 ): SnakeCase<T>;
 export function snakeCase<T extends string | readonly string[]>(string_?: T) {
   return kebabCase(string_ || "", "_") as SnakeCase<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,10 +105,12 @@ export function camelCase<T extends string | readonly string[]>(string_?: T) {
   return lowerFirst(pascalCase(string_ || "")) as CamelCase<T>;
 }
 
+export type KebabCase<T extends string | readonly string[]> = JoinByCase<T, "-">
+
 export function kebabCase(): "";
 export function kebabCase<T extends string | readonly string[]>(
   string_: T
-): JoinByCase<T, "-">;
+): KebabCase<T>;
 export function kebabCase<
   T extends string | readonly string[],
   Joiner extends string
@@ -124,10 +126,12 @@ export function kebabCase<
         .join(joiner ?? "-") as JoinByCase<T, Joiner>);
 }
 
+export type SnakeCase<T extends string | readonly string[]> = JoinByCase<T, "_">
+
 export function snakeCase(): "";
 export function snakeCase<T extends string | readonly string[]>(
   string_: T
-): JoinByCase<T, "_">;
+): SnakeCase<T>;
 export function snakeCase<T extends string | readonly string[]>(string_?: T) {
-  return kebabCase(string_ || "", "_") as JoinByCase<T, "_">;
+  return kebabCase(string_ || "", "_") as SnakeCase<T>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { CamelCase, JoinByCase, PascalCase, SplitByCase } from "./types";
 
+export type { CamelCase, JoinByCase, PascalCase, SplitByCase };
+
 const NUMBER_CHAR_RE = /\d/;
 const STR_SPLITTERS = ["-", "_", "/", "."] as const;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,18 @@ export type SplitByCase<
     : string[]
   : Accumulator;
 
+type JoinByCase<T, Joiner extends string> = string extends T
+  ? string
+  : string[] extends T
+  ? string
+  : T extends string
+  ? SplitByCase<T> extends readonly string[]
+    ? JoinLowercaseWords<SplitByCase<T>, Joiner>
+    : never
+  : T extends readonly string[]
+  ? JoinLowercaseWords<T, Joiner>
+  : never;
+
 export type PascalCase<T> = string extends T
   ? string
   : string[] extends T
@@ -114,17 +126,15 @@ export type CamelCase<T> = string extends T
   ? string
   : Uncapitalize<PascalCase<T>>;
 
-export type JoinByCase<T, Joiner extends string> = string extends T
-  ? string
-  : string[] extends T
-  ? string
-  : T extends string
-  ? SplitByCase<T> extends readonly string[]
-    ? JoinLowercaseWords<SplitByCase<T>, Joiner>
-    : never
-  : T extends readonly string[]
-  ? JoinLowercaseWords<T, Joiner>
-  : never;
+export type KebabCase<
+  T extends string | readonly string[],
+  Joiner extends string = "-"
+> = JoinByCase<T, Joiner>;
+
+export type SnakeCase<T extends string | readonly string[]> = JoinByCase<
+  T,
+  "_"
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type __tests = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,14 +102,14 @@ export type SplitByCase<
 type JoinByCase<T, Joiner extends string> = string extends T
   ? string
   : string[] extends T
-  ? string
-  : T extends string
-  ? SplitByCase<T> extends readonly string[]
-    ? JoinLowercaseWords<SplitByCase<T>, Joiner>
-    : never
-  : T extends readonly string[]
-  ? JoinLowercaseWords<T, Joiner>
-  : never;
+    ? string
+    : T extends string
+      ? SplitByCase<T> extends readonly string[]
+        ? JoinLowercaseWords<SplitByCase<T>, Joiner>
+        : never
+      : T extends readonly string[]
+        ? JoinLowercaseWords<T, Joiner>
+        : never;
 
 export type PascalCase<T> = string extends T
   ? string
@@ -129,10 +129,9 @@ export type CamelCase<T> = string extends T
     ? string
     : Uncapitalize<PascalCase<T>>;
 
-
 export type KebabCase<
   T extends string | readonly string[],
-  Joiner extends string = "-"
+  Joiner extends string = "-",
 > = JoinByCase<T, Joiner>;
 
 export type SnakeCase<T extends string | readonly string[]> = JoinByCase<


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/23696

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This exports type helpers matching the functions/return types of the helpers scule offers.

Ideally this should mean if https://github.com/unjs/scule/issues/57 lands, we can just update the implementation of these types rather than have a breaking change.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
