### PR TITLE
fix(pascalCase, camelCase): lower rest of each segment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export function pascalCase<T extends string | readonly string[]>(
 export function pascalCase<T extends string | readonly string[]>(str?: T) {
   return str
     ? ((Array.isArray(str) ? str : splitByCase(str as string))
-        .map((p) => upperFirst(p))
+        .map((p) => upperFirst(p.toLowerCase()))
         .join("") as PascalCase<T>)
     : "";
 }

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -15,8 +15,10 @@ describe("splitByCase", () => {
     ["foo", ["foo"]],
     ["fooBar", ["foo", "Bar"]],
     ["FooBarBaz", ["Foo", "Bar", "Baz"]],
+    ["FooBARb", ["Foo", "BA", "Rb"]],
     ["foo_bar-baz/qux", ["foo", "bar", "baz", "qux"]],
     ["foo--bar-Baz", ["foo", "", "bar", "Baz"]],
+    ["FOO_BAR", ["FOO", "BAR"]],
     ["foo123-bar", ["foo123", "bar"]],
     ["FOOBar", ["FOO", "Bar"]],
     ["ALink", ["A", "Link"]],
@@ -40,8 +42,9 @@ describe("pascalCase", () => {
     ["", ""],
     ["foo", "Foo"],
     ["foo-bAr", "FooBAr"],
-    ["FooBARb", "FooBARb"],
+    ["FooBARb", "FooBaRb"],
     ["foo_bar-baz/qux", "FooBarBazQux"],
+    ["FOO_BAR", "FooBar"],
     ["foo--bar-Baz", "FooBarBaz"],
   ])("%s => %s", (input, expected) => {
     expect(pascalCase(input)).toMatchObject(expected);
@@ -49,7 +52,7 @@ describe("pascalCase", () => {
 });
 
 describe("camelCase", () => {
-  test.each([["FooBarBaz", "fooBarBaz"]])("%s => %s", (input, expected) => {
+  test.each([["FooBarBaz", "fooBarBaz"], ["FOO_BAR", "fooBar"],])("%s => %s", (input, expected) => {
     expect(camelCase(input)).toMatchObject(expected);
   });
 });
@@ -63,13 +66,14 @@ describe("kebabCase", () => {
     ["foo--bar", "foo--bar"],
     ["FooBAR", "foo-bar"],
     ["ALink", "a-link"],
+    ["FOO_BAR", "foo-bar"],
   ])("%s => %s", (input, expected) => {
     expect(kebabCase(input)).toMatchObject(expected);
   });
 });
 
 describe("snakeCase", () => {
-  test.each([["FooBarBaz", "foo_bar_baz"]])("%s => %s", (input, expected) => {
+  test.each([["FooBarBaz", "foo_bar_baz"], ["FOO_BAR", "foo_bar"],])("%s => %s", (input, expected) => {
     expect(snakeCase(input)).toMatchObject(expected);
   });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #53

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For PascalCase and camelCase (which depends in Pascal util), we were splitting but then preserving cases of each segment which could be upper or lower. 

Before: `FOO_BAR` => pascal: `FOOBAR` camel: `fOOBAR`
After: `FOO_BAR` => pascal: `FooBar` camel: `fooBar`

This has small regression but i think right fix for the purpose of the utils.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
