### PR TITLE
fix(isUppercase): assume characters lowercase by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {
     return undefined;
   }
-  return char.toUpperCase() === char;
+  return char !== char.toLowerCase();
 }
 
 export function splitByCase<T extends string>(str: T): SplitByCase<T>;

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -30,6 +30,7 @@ describe("splitByCase", () => {
       ["foo", "Bar", "fuzz", "FI", "Zz"],
       ["\\", ".", "-"],
     ],
+    ["new-name-value", ["new-name-value"], ["_"]],
   ])("%s => %s", (input, expected, customSplitters?) => {
     if (customSplitters) {
       expect(splitByCase(input, customSplitters)).toMatchObject(expected);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #69

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`isUppercase` is used to return `true` for nonalphabetic characters such as `-`. This issue was not visible for the `splitByCase` util without custom splitters.

The fix checkes if string could be lowecased, it is an uppercase. (also adds tiny perf because the frequency of passed lowercase strings is much higher and it saves v8 engine to do anything for most of `toLowercase()` calls

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
