### PR TITLE
feat: title case util

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ flatCase("foo-barBaz");
 // foobarbaz
 ```
 
-### `trainCase(str, opts?: { normalize })`
+### `trainCase(str, opts?: { normalize, joiner })`
 
 Split string and joins by Train-Case (a.k.a. HTTP-Header-Case) convention:
 
@@ -88,6 +88,17 @@ trainCase("FooBARb");
 ```
 
 **Notice:** If an uppercase letter is followed by other uppercase letters (like `WWWAuthenticate`), they are preserved (=> `WWW-Authenticate`). You can use `{ normalize: true }` for strictly only having the first letter uppercased.
+
+### `titleCase(str, opts?: { normalize })`
+
+With Title Case all words are capitalized, except for minor words.
+
+A compact regex of common minor words (such as `a`, `for`, `to`) is used to automatically keep the lower case.
+
+```ts
+titleCase("this-IS-aTitle");
+// This is a title
+```
 
 ### `upperFirst(str)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,4 +169,29 @@ export function trainCase<
     .join("-") as TrainCase<T, UserCaseOptions["normalize"]>;
 }
 
+const titleCaseExceptions =
+  /^(a|an|and|as|at|but|by|for|if|in|is|nor|of|on|or|the|to|with)$/i;
+
+export function titleCase(): "";
+export function titleCase<
+  T extends string | readonly string[],
+  UserCaseOptions extends CaseOptions = CaseOptions,
+>(
+  str: T,
+  opts?: UserCaseOptions,
+): TrainCase<T, UserCaseOptions["normalize"], " ">;
+export function titleCase<
+  T extends string | readonly string[],
+  UserCaseOptions extends CaseOptions = CaseOptions,
+>(str?: T, opts?: UserCaseOptions) {
+  return (Array.isArray(str) ? str : splitByCase(str as string))
+    .filter(Boolean)
+    .map((p) =>
+      titleCaseExceptions.test(p)
+        ? p.toLowerCase()
+        : upperFirst(opts?.normalize ? p.toLowerCase() : p),
+    )
+    .join(" ") as TrainCase<T, UserCaseOptions["normalize"]>;
+}
+
 export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,14 @@ type RemoveFirstOfString<S extends string> = S extends `${string}${infer R}`
   : never;
 type IsUpper<S extends string> = S extends Uppercase<S> ? true : false;
 type IsLower<S extends string> = S extends Lowercase<S> ? true : false;
-type SameLetterCase<X extends string, Y extends string> =
-  IsUpper<X> extends IsUpper<Y>
+type SameLetterCase<
+  X extends string,
+  Y extends string,
+> = IsUpper<X> extends IsUpper<Y>
+  ? true
+  : IsLower<X> extends IsLower<Y>
     ? true
-    : IsLower<X> extends IsLower<Y>
-      ? true
-      : false;
+    : false;
 type CapitalizedWords<
   T extends readonly string[],
   Accumulator extends string = "",
@@ -148,16 +150,17 @@ export type SnakeCase<T extends string | readonly string[]> = JoinByCase<
 export type TrainCase<
   T,
   Normalize extends boolean | undefined = false,
+  Joiner extends string = "-",
 > = string extends T
   ? string
   : string[] extends T
     ? string
     : T extends string
       ? SplitByCase<T> extends readonly string[]
-        ? CapitalizedWords<SplitByCase<T>, "-">
+        ? CapitalizedWords<SplitByCase<T>, Joiner>
         : never
       : T extends readonly string[]
-        ? CapitalizedWords<T, "-", Normalize>
+        ? CapitalizedWords<T, Joiner, Normalize>
         : never;
 
 export type FlatCase<

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -9,6 +9,7 @@ import {
   snakeCase,
   trainCase,
   flatCase,
+  titleCase,
 } from "../src";
 
 describe("splitByCase", () => {
@@ -129,6 +130,18 @@ describe("trainCase", () => {
     ["WWW-authenticate", "Www-Authenticate"],
   ])("%s => %s", (input, expected) => {
     expect(trainCase(input, { normalize: true })).toMatchObject(expected);
+  });
+});
+
+describe("titleCase", () => {
+  test.each([
+    ["", ""],
+    ["f", "F"],
+    ["foo", "Foo"],
+    ["foo-bar", "Foo Bar"],
+    ["this-IS-aTitle", "This is a Title"],
+  ])("%s => %s", (input, expected) => {
+    expect(titleCase(input)).toMatchObject(expected);
   });
 });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a new `titleCase` utility. 

I have reused the `trainCase` type utils extended to support ` ` joiner but the types are not accurate (and traincase types are also seem not working properly)

For runtime impl I have essentially duplicated logic because this allows to independently improve them both without adding more complexity.

I also used a compact regex that handles very common exceptions that need to be lowercased. A compromise that is not perfect but better than random inline `-` to ` ` replaces we use everywhere to have title-case-like output.

ideas welcome to improve 👍🏼 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
