### PR TITLE
fix(titleCase): insert extra space when convert valid string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,7 @@ export function titleCase<
 >(str?: T, opts?: UserCaseOptions) {
   return (Array.isArray(str) ? str : splitByCase(str as string))
     .filter(Boolean)
+    .map((p) => p.trim())
     .map((p) =>
       titleCaseExceptions.test(p)
         ? p.toLowerCase()

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export function splitByCase<
     // Splitter
     const isSplitter = (splitters as unknown as string).includes(char);
     if (isSplitter === true) {
-      parts.push(buff);
+      parts.push(buff.trim());
       buff = "";
       previousUpper = undefined;
       continue;
@@ -54,7 +54,7 @@ export function splitByCase<
     if (previousSplitter === false) {
       // Case rising edge
       if (previousUpper === false && isUpper === true) {
-        parts.push(buff);
+        parts.push(buff.trim());
         buff = char;
         previousUpper = isUpper;
         continue;
@@ -62,7 +62,7 @@ export function splitByCase<
       // Case falling edge
       if (previousUpper === true && isUpper === false && buff.length > 1) {
         const lastChar = buff.at(-1);
-        parts.push(buff.slice(0, Math.max(0, buff.length - 1)));
+        parts.push(buff.slice(0, Math.max(0, buff.length - 1)).trim());
         buff = lastChar + char;
         previousUpper = isUpper;
         continue;
@@ -75,7 +75,7 @@ export function splitByCase<
     previousSplitter = isSplitter;
   }
 
-  parts.push(buff);
+  parts.push(buff.trim());
 
   return parts as SplitByCase<T, Separator[number]>;
 }
@@ -186,7 +186,6 @@ export function titleCase<
 >(str?: T, opts?: UserCaseOptions) {
   return (Array.isArray(str) ? str : splitByCase(str as string))
     .filter(Boolean)
-    .map((p) => p.trim())
     .map((p) =>
       titleCaseExceptions.test(p)
         ? p.toLowerCase()

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,17 +13,30 @@ type SameLetterCase<X extends string, Y extends string> =
     : IsLower<X> extends IsLower<Y>
       ? true
       : false;
+
 type CapitalizedWords<
   T extends readonly string[],
-  Accumulator extends string = "",
+  Joiner extends string,
   Normalize extends boolean | undefined = false,
-> = T extends readonly [infer F extends string, ...infer R extends string[]]
-  ? CapitalizedWords<
-      R,
-      `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}`,
-      Normalize
-    >
-  : Accumulator;
+  Accumulator extends string = "",
+> = T extends readonly []
+  ? Accumulator
+  : T extends readonly [infer F extends string]
+    ? CapitalizedWords<
+        [],
+        Joiner,
+        Normalize,
+        `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}`
+      >
+    : T extends readonly [infer F extends string, ...infer R extends string[]]
+      ? CapitalizedWords<
+          R,
+          Joiner,
+          Normalize,
+          `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}${Joiner}`
+        >
+      : Accumulator;
+
 type JoinLowercaseWords<
   T extends readonly string[],
   Joiner extends string,
@@ -38,6 +51,41 @@ type LastOfArray<T extends any[]> = T extends [...any, infer R] ? R : never;
 type RemoveLastOfArray<T extends any[]> = T extends [...infer F, any]
   ? F
   : never;
+
+type Whitespace =
+  | "\u{9}" // '\t'
+  | "\u{A}" // '\n'
+  | "\u{B}" // '\v'
+  | "\u{C}" // '\f'
+  | "\u{D}" // '\r'
+  | "\u{20}" // ' '
+  | "\u{85}"
+  | "\u{A0}"
+  | "\u{1680}"
+  | "\u{2000}"
+  | "\u{2001}"
+  | "\u{2002}"
+  | "\u{2003}"
+  | "\u{2004}"
+  | "\u{2005}"
+  | "\u{2006}"
+  | "\u{2007}"
+  | "\u{2008}"
+  | "\u{2009}"
+  | "\u{200A}"
+  | "\u{2028}"
+  | "\u{2029}"
+  | "\u{202F}"
+  | "\u{205F}"
+  | "\u{3000}"
+  | "\u{FEFF}";
+type TrimLeft<T extends string> = T extends `${Whitespace}${infer R}`
+  ? TrimLeft<R>
+  : T;
+type TrimRight<T extends string> = T extends `${infer R}${Whitespace}`
+  ? TrimRight<R>
+  : T;
+type Trim<T extends string> = TrimLeft<TrimRight<T>>;
 
 export type CaseOptions = {
   normalize?: boolean;
@@ -59,7 +107,7 @@ export type SplitByCase<
               Separator,
               [
                 ...RemoveLastOfArray<Accumulator>,
-                `${LastOfArray<Accumulator>}${F}`,
+                Trim<`${LastOfArray<Accumulator>}${F}`>,
               ]
             >
           : SameLetterCase<F, FirstOfString<R>> extends true
@@ -78,7 +126,7 @@ export type SplitByCase<
                   Separator,
                   [
                     ...RemoveLastOfArray<Accumulator>,
-                    `${LastOfArray<Accumulator>}${F}`,
+                    Trim<`${LastOfArray<Accumulator>}${F}`>,
                   ]
                 >
             : IsLower<F> extends true
@@ -87,7 +135,7 @@ export type SplitByCase<
                   Separator,
                   [
                     ...RemoveLastOfArray<Accumulator>,
-                    `${LastOfArray<Accumulator>}${F}`,
+                    Trim<`${LastOfArray<Accumulator>}${F}`>,
                     FirstOfString<R>,
                   ]
                 >

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,21 +21,18 @@ type CapitalizedWords<
   Accumulator extends string = "",
 > = T extends readonly []
   ? Accumulator
-  : T extends readonly [infer F extends string]
+  : T extends readonly [infer F extends string, ...infer R extends string[]]
     ? CapitalizedWords<
-        [],
+        R,
         Joiner,
         Normalize,
-        `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}`
+        `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}${[
+          LastOfArray<R>,
+        ] extends [never]
+          ? ""
+          : Joiner}`
       >
-    : T extends readonly [infer F extends string, ...infer R extends string[]]
-      ? CapitalizedWords<
-          R,
-          Joiner,
-          Normalize,
-          `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}${Joiner}`
-        >
-      : Accumulator;
+    : Accumulator;
 
 type JoinLowercaseWords<
   T extends readonly string[],
@@ -99,7 +96,7 @@ export type SplitByCase<
   ? string[]
   : T extends `${infer F}${infer R}`
     ? [LastOfArray<Accumulator>] extends [never]
-      ? SplitByCase<R, Separator, [F]>
+      ? SplitByCase<R, Separator, F extends Separator | Whitespace ? [] : [F]>
       : LastOfArray<Accumulator> extends string
         ? R extends ""
           ? SplitByCase<

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -50,6 +50,7 @@ describe("pascalCase", () => {
     ["foo_bar-baz/qux", "FooBarBazQux"],
     ["FOO_BAR", "FooBar"],
     ["foo--bar-Baz", "FooBarBaz"],
+    ["FooBarBazQux", "FooBarBazQux"],
   ])("%s => %s", (input, expected) => {
     expect(pascalCase(input, { normalize: true })).toMatchObject(expected);
   });
@@ -59,6 +60,7 @@ describe("camelCase", () => {
   test.each([
     ["FooBarBaz", "fooBarBaz"],
     ["FOO_BAR", "fooBar"],
+    ["fooBarBaz", "fooBarBaz"],
   ])("%s => %s", (input, expected) => {
     expect(camelCase(input, { normalize: true })).toMatchObject(expected);
   });
@@ -74,6 +76,7 @@ describe("kebabCase", () => {
     ["FooBAR", "foo-bar"],
     ["ALink", "a-link"],
     ["FOO_BAR", "foo-bar"],
+    ["foo-b-ar", "foo-b-ar"],
   ])("%s => %s", (input, expected) => {
     expect(kebabCase(input)).toMatchObject(expected);
   });
@@ -83,6 +86,7 @@ describe("snakeCase", () => {
   test.each([
     ["FooBarBaz", "foo_bar_baz"],
     ["FOO_BAR", "foo_bar"],
+    ["foo_bar_baz", "foo_bar_baz"],
   ])("%s => %s", (input, expected) => {
     expect(snakeCase(input)).toMatchObject(expected);
   });
@@ -93,6 +97,7 @@ describe("upperFirst", () => {
     ["", ""],
     ["foo", "Foo"],
     ["Foo", "Foo"],
+    ["FooBarBaz", "FooBarBaz"],
   ])("%s => %s", (input, expected) => {
     expect(upperFirst(input)).toMatchObject(expected);
   });
@@ -103,6 +108,7 @@ describe("lowerFirst", () => {
     ["", ""],
     ["foo", "foo"],
     ["Foo", "foo"],
+    ["fooBarBaz", "fooBarBaz"],
   ])("%s => %s", (input, expected) => {
     expect(lowerFirst(input)).toMatchObject(expected);
   });
@@ -120,6 +126,7 @@ describe("trainCase", () => {
     ["foo--bar-Baz", "Foo-Bar-Baz"],
     ["WWW-authenticate", "WWW-Authenticate"],
     ["WWWAuthenticate", "WWW-Authenticate"],
+    ["Foo-B-Ar", "Foo-B-Ar"],
   ])("%s => %s", (input, expected) => {
     expect(trainCase(input)).toMatchObject(expected);
   });
@@ -140,6 +147,7 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["Foo Bar", "Foo Bar"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
   });
@@ -154,6 +162,7 @@ describe("flatCase", () => {
     ["foo_bar-baz/qux", "foobarbazqux"],
     ["FOO_BAR", "foobar"],
     ["foo--bar-Baz", "foobarbaz"],
+    ["foobarbaz", "foobarbaz"],
   ])("%s => %s", (input, expected) => {
     expect(flatCase(input)).toMatchObject(expected);
   });

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -25,6 +25,8 @@ describe("splitByCase", () => {
     ["foo123-bar", ["foo123", "bar"]],
     ["FOOBar", ["FOO", "Bar"]],
     ["ALink", ["A", "Link"]],
+    ["-FooBar", ["", "Foo", "Bar"]],
+    [" FooBar", ["", "Foo", "Bar"]],
     // with custom splitters
     [
       "foo\\Bar.fuzz-FIZz",

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -24,6 +24,8 @@ describe("SplitByCase", () => {
     assertType<SplitByCase<"ALink">>(["A", "Link"]);
     assertType<SplitByCase<"FOO_BAR">>(["FOO", "BAR"]);
     assertType<SplitByCase<"Foo Bar Baz">>(["Foo", "Bar", "Baz"]);
+    assertType<SplitByCase<"-Bar Baz">>(["Bar", "Baz"]);
+    assertType<SplitByCase<" Bar Baz">>(["Bar", "Baz"]);
   });
 
   test("custom splitters", () => {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -4,6 +4,7 @@ import type {
   PascalCase,
   CamelCase,
   JoinByCase,
+  TrainCase,
 } from "../src/types";
 
 describe("SplitByCase", () => {
@@ -22,6 +23,7 @@ describe("SplitByCase", () => {
     assertType<SplitByCase<"FOOBar">>(["FOO", "Bar"]);
     assertType<SplitByCase<"ALink">>(["A", "Link"]);
     assertType<SplitByCase<"FOO_BAR">>(["FOO", "BAR"]);
+    assertType<SplitByCase<"Foo Bar Baz">>(["Foo", "Bar", "Baz"]);
   });
 
   test("custom splitters", () => {
@@ -50,6 +52,7 @@ describe("PascalCase", () => {
     assertType<PascalCase<"foo_bar-baz/qux", true>>("FooBarBazQux");
     assertType<PascalCase<"foo--bar-Baz", true>>("FooBarBaz");
     assertType<PascalCase<"FOO_BAR", true>>("FooBar");
+    assertType<PascalCase<"FooBarBaz", true>>("FooBarBaz");
   });
 
   test("array", () => {
@@ -72,6 +75,7 @@ describe("CamelCase", () => {
     assertType<CamelCase<"FooBARb", true>>("fooBaRb");
     assertType<CamelCase<"foo_bar-baz/qux", true>>("fooBarBazQux");
     assertType<CamelCase<"FOO_BAR", true>>("fooBar");
+    assertType<CamelCase<"fooBarBaz", true>>("fooBarBaz");
   });
 
   test("array", () => {
@@ -90,9 +94,59 @@ describe("JoinByCase", () => {
     assertType<JoinByCase<"foo", "-">>("foo");
     assertType<JoinByCase<"FooBARb", "-">>("foo-ba-rb");
     assertType<JoinByCase<"foo_bar-baz/qux", "-">>("foo-bar-baz-qux");
+    assertType<JoinByCase<"foo-bar-baz", "-">>("foo-bar-baz");
   });
 
   test("array", () => {
     assertType<JoinByCase<["Foo", "Bar"], "-">>("foo-bar");
+  });
+});
+
+describe("TrainCase", () => {
+  test("types", () => {
+    expectTypeOf<TrainCase<string>>().toEqualTypeOf<string>();
+    expectTypeOf<TrainCase<string[]>>().toEqualTypeOf<string>();
+  });
+
+  test("string", () => {
+    assertType<TrainCase<"">>("");
+    assertType<TrainCase<"f">>("F");
+    assertType<TrainCase<"foo">>("Foo");
+    assertType<TrainCase<"foo-bAr">>("Foo-B-Ar");
+    assertType<TrainCase<"AcceptCH">>("Accept-CH");
+    assertType<TrainCase<"foo_bar-baz/qux">>("Foo-Bar-Baz-Qux");
+    assertType<TrainCase<"FOO_BAR">>("FOO-BAR");
+    // @ts-expect-error - splitByCase result may contain empty string
+    assertType<TrainCase<"foo--bar-Baz">>("Foo-Bar-Baz");
+    assertType<TrainCase<"WWW-authenticate">>("WWW-Authenticate");
+    assertType<TrainCase<"WWWAuthenticate">>("WWW-Authenticate");
+    assertType<TrainCase<"Foo-B-Ar">>("Foo-B-Ar");
+  });
+
+  test("array", () => {
+    assertType<TrainCase<[]>>("");
+    assertType<TrainCase<["foo", "bar"]>>("Foo-Bar");
+  });
+});
+
+describe("TitleCase", () => {
+  test("string", () => {
+    assertType<TrainCase<"">>("");
+    assertType<TrainCase<"f", false, " ">>("F");
+    assertType<TrainCase<"foo", false, " ">>("Foo");
+    assertType<TrainCase<"foo-bAr", false, " ">>("Foo B Ar");
+    assertType<TrainCase<"AcceptCH", false, " ">>("Accept CH");
+    assertType<TrainCase<"foo_bar-baz/qux", false, " ">>("Foo Bar Baz Qux");
+    assertType<TrainCase<"FOO_BAR", false, " ">>("FOO BAR");
+    // @ts-expect-error - splitByCase result may contain empty string
+    assertType<TrainCase<"foo--bar-Baz", false, " ">>("Foo Bar Baz");
+    assertType<TrainCase<"WWW-authenticate", false, " ">>("WWW Authenticate");
+    assertType<TrainCase<"WWWAuthenticate", false, " ">>("WWW Authenticate");
+    assertType<TrainCase<"Foo-B-Ar", false, " ">>("Foo B Ar");
+  });
+
+  test("array", () => {
+    assertType<TrainCase<[]>>("");
+    assertType<TrainCase<["foo", "bar"], false, " ">>("Foo Bar");
   });
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR resolves #96 and adds test cases for other converters while convert valid string.