### PR TITLE
fix: Split by case should take space into account

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ lowerFirst("Hello world!");
 
 ### `splitByCase(str, splitters?)`
 
-- Splits string by the splitters provided (default: `['-', '_', '/', '.']`)
+- Splits string by the splitters provided (default: `['-', '_', '/', '.', ' ']`)
 - Splits when case changes from lower to upper or upper to lower
 - Ignores numbers for case changes
 - Case is preserved in returned value

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types";
 
 const NUMBER_CHAR_RE = /\d/;
-const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const STR_SPLITTERS = ["-", "_", "/", ".", " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {
@@ -186,8 +186,8 @@ export function titleCase<
 >(str?: T, opts?: UserCaseOptions) {
   return (Array.isArray(str) ? str : splitByCase(str as string))
     .filter(Boolean)
-    .map((p) =>
-      titleCaseExceptions.test(p)
+    .map((p, i) =>
+      i && titleCaseExceptions.test(p)
         ? p.toLowerCase()
         : upperFirst(opts?.normalize ? p.toLowerCase() : p),
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,8 +186,8 @@ export function titleCase<
 >(str?: T, opts?: UserCaseOptions) {
   return (Array.isArray(str) ? str : splitByCase(str as string))
     .filter(Boolean)
-    .map((p, i) =>
-      i && titleCaseExceptions.test(p)
+    .map((p, index) =>
+      index > 0 && titleCaseExceptions.test(p)
         ? p.toLowerCase()
         : upperFirst(opts?.normalize ? p.toLowerCase() : p),
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-type Splitter = "-" | "_" | "/" | ".";
+type Splitter = "-" | "_" | "/" | "." | " ";
 type FirstOfString<S extends string> = S extends `${infer F}${string}`
   ? F
   : never;

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,7 +140,7 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
-    ["is_thisATitle", "Is This a Title"],
+    ["is_this ATitle", "Is This a Title"],
     ["hello, world!", "Hello, World!"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,6 +140,8 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["is_thisATitle", "Is This a Title"],
+    ["hello, world!", "Hello, World!"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
   });

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -22,6 +22,7 @@ describe("SplitByCase", () => {
     assertType<SplitByCase<"FOOBar">>(["FOO", "Bar"]);
     assertType<SplitByCase<"ALink">>(["A", "Link"]);
     assertType<SplitByCase<"FOO_BAR">>(["FOO", "BAR"]);
+    assertType<SplitByCase<"FOO BAR">>(["FOO", "BAR"]);
   });
 
   test("custom splitters", () => {


### PR DESCRIPTION
fix #95 
fix #92 

I think for the `titleCase`, the `,` should not be took into account.
