### PR TITLE
fix(titleCase):skip exception test on first word

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,8 +186,8 @@ export function titleCase<
 >(str?: T, opts?: UserCaseOptions) {
   return (Array.isArray(str) ? str : splitByCase(str as string))
     .filter(Boolean)
-    .map((p) =>
-      titleCaseExceptions.test(p)
+    .map((p, index) =>
+      index !== 0 && titleCaseExceptions.test(p)
         ? p.toLowerCase()
         : upperFirst(opts?.normalize ? p.toLowerCase() : p),
     )

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,6 +140,7 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["is-a-title", "Is a Title"]
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
   });


### PR DESCRIPTION
Resolves #101

Ensures the first word is transformed to *Upper-first* regardless whether or not it's an exception word

```
titleCase('a-world')
// Before 'a World'
// After 'A world'
```
