### PR TITLE
Fix titleCase inserting extra space for input with spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types";
 
 const NUMBER_CHAR_RE = /\d/;
-const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const STR_SPLITTERS = ["-", "_", "/", ".", " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {


### PR DESCRIPTION
Fixes #96. The splitByCase function did not include space as a splitter character, causing inputs like 'Hello World' to be incorrectly split at case transitions ('o' to 'W') producing 'Hell  World' with an extra space. This fix adds space to STR_SPLITTERS so it is treated as a separator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spaces are now recognized as string delimiters when splitting strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->