### PR TITLE
fix(types): TrainCase should insert joiner between tokens, not as prefix

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,17 @@ export type SnakeCase<T extends string | readonly string[]> = JoinByCase<
   "_"
 >;
 
+type JoinCapitalizedWords<
+  T extends readonly string[],
+  Joiner extends string,
+  Accumulator extends string = "",
+  Normalize extends boolean | undefined = false,
+> = T extends readonly [infer F extends string, ...infer R extends string[]]
+  ? Accumulator extends ""
+    ? JoinCapitalizedWords<R, Joiner, Capitalize<Normalize extends true ? Lowercase<F> : F>, Normalize>
+    : JoinCapitalizedWords<R, Joiner, `${Accumulator}${Joiner}${Capitalize<Normalize extends true ? Lowercase<F> : F>}`, Normalize>
+  : Accumulator;
+
 export type TrainCase<
   T,
   Normalize extends boolean | undefined = false,
@@ -155,10 +166,10 @@ export type TrainCase<
     ? string
     : T extends string
       ? SplitByCase<T> extends readonly string[]
-        ? CapitalizedWords<SplitByCase<T>, Joiner>
+        ? JoinCapitalizedWords<SplitByCase<T>, Joiner, "", Normalize>
         : never
       : T extends readonly string[]
-        ? CapitalizedWords<T, Joiner, Normalize>
+        ? JoinCapitalizedWords<T, Joiner, "", Normalize>
         : never;
 
 export type FlatCase<


### PR DESCRIPTION
Fixes #110

## Problem

The `TrainCase` type passes the `Joiner` parameter as the `Accumulator` to `CapitalizedWords`, causing the joiner to be **prepended** to the output instead of inserted between tokens.

```ts
// Current (broken)
TrainCase<"hello_world"> // => "-HelloWorld"

// Expected
TrainCase<"hello_world"> // => "Hello-World"
```

## Root Cause

`CapitalizedWords` uses the second parameter as an initial accumulator value. `TrainCase` passes `Joiner` as the `Accumulator`, resulting in `${"-"}${Capitalize<"hello">}` = `"-Hello"`.

## Fix

Added `JoinCapitalizedWords` type that properly inserts the joiner between tokens, following the same pattern as the existing `JoinLowercaseWords`. The first word has no prefix, subsequent words are preceded by the joiner.

## Verification

The runtime `trainCase` function already works correctly (uses `.join("-")`). This fix aligns the type-level behavior with the runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal type system improvements with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->