### PR TITLE
fix: add space as word splitter to fix titleCase extra spaces (#96)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types";
 
 const NUMBER_CHAR_RE = /\d/;
-const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const STR_SPLITTERS = ["-", "_", "/", ".", " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {


### PR DESCRIPTION
### Linked issue

Closes #96

### Description

`titleCase('Hello World')` returns `'hello  World'` (double space). Calling it again produces `'hello   World'` (triple space).

**Root cause:** `STR_SPLITTERS` does not include space. When `splitByCase('Hello World')` processes the input, the uppercase `W` triggers a rising-edge split at index 6, producing `['Hello ', 'World']` — the trailing space stays attached to the first part. Then `titleCase` joins with `' '`, creating the double space.

### Fix

Add `" "` to `STR_SPLITTERS` so spaces are treated as word boundaries during case splitting:

```diff
- const STR_SPLITTERS = ['-', '_', '/', '.'] as const;
+ const STR_SPLITTERS = ['-', '_', '/', '.', ' '] as const;
```

After this fix:
- `titleCase('Hello World')` → `'Hello World'` (correct)
- `titleCase(titleCase('Hello World'))` → `'Hello World'` (idempotent)
- `splitByCase('Hello World')` → `['Hello', 'World']` (clean split)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text casing functions now treat spaces as separators by default when converting text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->