### PR TITLE
fix(titleCase): trim whitespace to prevent extra spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,7 @@ export function titleCase<
   UserCaseOptions extends CaseOptions = CaseOptions,
 >(str?: T, opts?: UserCaseOptions) {
   return (Array.isArray(str) ? str : splitByCase(str as string))
+    .map((p) => p.trim())
     .filter(Boolean)
     .map((p) =>
       titleCaseExceptions.test(p)

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,8 +140,14 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["Hello World", "Hello World"],
+    ["Hello  World", "Hello World"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
+  });
+
+  test("titleCase is idempotent", () => {
+    expect(titleCase(titleCase("Hello World"))).toBe("Hello World");
   });
 });
 


### PR DESCRIPTION
### Bug Description

When input contains spaces (e.g. `titleCase('Hello World')`), `splitByCase` preserves the trailing space in the first part (`"Hello "`). `titleCase` then joins parts with spaces, producing double spaces (`"Hello  World"`).

This also breaks idempotency: `titleCase(titleCase('Hello World'))` produces progressively more spaces.

### Root Cause

`splitByCase` does not split on spaces, so `"Hello World"` becomes `["Hello ", "World"]`. The trailing space in the first part is not trimmed before joining with `" "`.

### Fix

Add  before the filter step in `titleCase` to strip leading/trailing whitespace from each split part.

Fixes #96

### Test Results

All 66 tests pass, including new tests for space-containing input and idempotency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of whitespace by normalizing multiple consecutive spaces to single spaces.

* **Tests**
  * Added test cases verifying whitespace preservation and normalization behavior.
  * Added idempotency verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->