### PR TITLE
fix(titleCase): extra spaces when input already contains spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types";
 
 const NUMBER_CHAR_RE = /\d/;
-const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const STR_SPLITTERS = ["-", "_", "/", ".", " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,6 +140,9 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["Hello World", "Hello World"],
+    ["hello world", "Hello World"],
+    ["Hello  World", "Hello World"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
   });


### PR DESCRIPTION
Fixes #96

## Problem

`titleCase('Hello World')` produces `'Hello  World'` (double space). Calling `titleCase(titleCase('hello'))` also produces double spaces because `splitByCase` does not recognize space as a separator.

Root cause: `splitByCase` uses `STR_SPLITTERS = ['-', '_', '/', '.']` but does not include space. When processing `'Hello World'`, the falling-edge detection at the space character (uppercase W → space) splits the string incorrectly, attaching the space to the preceding token: `['Hello ', 'World']`.

## Fix

Added space to `STR_SPLITTERS`. Now `splitByCase('Hello World')` correctly returns `['Hello', 'World']`, and `titleCase` joins them with a single space.

This also improves `camelCase`, `kebabCase`, `snakeCase`, etc. for space-separated input.

## Tests

- All existing 63 tests pass
- Added 3 new test cases: `Hello World`, `hello world`, `Hello  World`
- Verified `titleCase` is now idempotent: `titleCase(titleCase('hello')) === 'Hello'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text splitting behavior by properly treating spaces as delimiters during case-based operations.
  * Enhanced whitespace normalization when formatting text in title case, now correctly handling multiple consecutive spaces.

* **Tests**
  * Expanded test coverage for multi-word input scenarios and whitespace handling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->