### PR TITLE
fix: correctly lowercase leading uppercase acronyms in camelCase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,10 +113,25 @@ export function camelCase<
   T extends string | readonly string[],
   UserCaseOptions extends CaseOptions = CaseOptions,
 >(str?: T, opts?: UserCaseOptions) {
-  return lowerFirst(pascalCase(str || "", opts)) as CamelCase<
-    T,
-    UserCaseOptions["normalize"]
-  >;
+  const words = Array.isArray(str) ? str : splitByCase((str || "") as string);
+  if (words.length === 0) {
+    return "" as CamelCase<T, UserCaseOptions["normalize"]>;
+  }
+  // If every word is all-uppercase (SCREAMING_SNAKE_CASE), the acronym
+  // boundaries are ambiguous — normalize all words (e.g. MY_API_KEY → myApiKey).
+  // Otherwise preserve the author's casing intent and only fix the leading
+  // all-uppercase word (e.g. APIBaseURL → apiBaseURL, parseXML → parseXML).
+  const allScreaming = words.every((w) => /^[A-Z]+$/.test(w));
+  return words
+    .map((p, i) => {
+      if (i === 0) {
+        return allScreaming || /^[A-Z]+$/.test(p)
+          ? p.toLowerCase()
+          : lowerFirst(p);
+      }
+      return upperFirst(allScreaming || opts?.normalize ? p.toLowerCase() : p);
+    })
+    .join("") as CamelCase<T, UserCaseOptions["normalize"]>;
 }
 
 export function kebabCase(): "";

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -59,8 +59,34 @@ describe("camelCase", () => {
   test.each([
     ["FooBarBaz", "fooBarBaz"],
     ["FOO_BAR", "fooBar"],
-  ])("%s => %s", (input, expected) => {
+  ])("%s => %s (normalize)", (input, expected) => {
     expect(camelCase(input, { normalize: true })).toMatchObject(expected);
+  });
+
+  test.each([
+    // leading acronym — fully lowercased
+    ["APIBaseURL", "apiBaseURL"],
+    ["XMLParser", "xmlParser"],
+    ["HTTPSResponse", "httpsResponse"],
+    ["API_Base_URL", "apiBaseURL"],
+    // SCREAMING_SNAKE_CASE — normalized (boundaries ambiguous)
+    ["API_BASE_URL", "apiBaseUrl"],
+    ["MY_API_KEY", "myApiKey"],
+    ["FOO_BAR", "fooBar"],
+    // mixed-case — author intent preserved
+    ["parseXML", "parseXML"],
+    ["myAPIKey", "myAPIKey"],
+    ["getHTTPSResponse", "getHTTPSResponse"],
+    ["fooBAR", "fooBAR"],
+    // basic cases
+    ["", ""],
+    ["fooBar", "fooBar"],
+    ["FooBar", "fooBar"],
+    ["FOOBar", "fooBar"],
+    ["foo_bar", "fooBar"],
+    ["foo-bar", "fooBar"],
+  ])("%s => %s", (input, expected) => {
+    expect(camelCase(input)).toMatchObject(expected);
   });
 });
 


### PR DESCRIPTION
Fixes #123

`camelCase()` only lowercased the first character of a leading uppercase acronym (e.g. `APIBaseURL` → `aPIBaseURL` instead of `apiBaseURL`). This was caused by `lowerFirst(pascalCase(str))` — `pascalCase` preserves `API` as `API`, then `lowerFirst` only drops the `A`.

`camelCase` is rewritten to use `splitByCase` directly with two heuristics:

- **Leading all-uppercase word** — fully lowercased (`APIBaseURL` → `apiBaseURL`, `XMLParser` → `xmlParser`)
- **SCREAMING_SNAKE_CASE** (all words uppercase) — all words normalized, since boundaries are ambiguous (`MY_API_KEY` → `myApiKey`)
- **Mixed-case / author-intent** — non-leading acronyms unchanged (`parseXML` → `parseXML`, `myAPIKey` → `myAPIKey`)

| Input | Before | After |
|---|---|---|
| `APIBaseURL` | `aPIBaseURL` | `apiBaseURL` |
| `API_BASE_URL` | `aPIBASEURL` | `apiBaseUrl` |
| `XMLParser` | `xMLParser` | `xmlParser` |
| `HTTPSResponse` | `hTTPSResponse` | `httpsResponse` |
| `MY_API_KEY` | `mYAPIKEY` | `myApiKey` |
| `parseXML` | `parseXML` | `parseXML` |
| `myAPIKey` | `myAPIKey` | `myAPIKey` |
| `hello_world` | `helloWorld` | `helloWorld` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how acronym-like inputs and mixed-case text are processed with refined normalization behavior
  * Enhanced handling of leading uppercase characters in case conversion

* **Tests**
  * Added expanded test coverage for case conversion with focus on acronyms, mixed-case preservation, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->