### PR TITLE
fix(kebabCase): split on spaces when building slugs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import type {
 
 const NUMBER_CHAR_RE = /\d/;
 const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const KEBAB_SPLITTERS = [...STR_SPLITTERS, " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {
@@ -132,7 +133,7 @@ export function kebabCase<
   Joiner extends string,
 >(str?: T, joiner?: Joiner) {
   return str
-    ? ((Array.isArray(str) ? str : splitByCase(str as string))
+    ? ((Array.isArray(str) ? str : splitByCase(str as string, KEBAB_SPLITTERS))
         .map((p) => p.toLowerCase())
         .join(joiner ?? "-") as KebabCase<T, Joiner>)
     : "";

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -74,6 +74,7 @@ describe("kebabCase", () => {
     ["FooBAR", "foo-bar"],
     ["ALink", "a-link"],
     ["FOO_BAR", "foo-bar"],
+    ["A string with Spaces", "a-string-with-spaces"],
   ])("%s => %s", (input, expected) => {
     expect(kebabCase(input)).toMatchObject(expected);
   });


### PR DESCRIPTION
## Summary

- Treat spaces as word separators in `kebabCase` (alongside `-`, `_`, `/`, `.`)
- Strings like `"A string with Spaces"` now become `a-string-with-spaces`

Fixes #86

## Test plan

- [x] Added test case for space-separated input
- [x] `pnpm test` (76 tests pass, 100% statement coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kebab-case conversion to treat spaces as separators, ensuring consistent formatting of strings with spaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/scule/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->