### PR TITLE
fix(titleCase): capitalize first word and split on spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import type {
 
 const NUMBER_CHAR_RE = /\d/;
 const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const KEBAB_SPLITTERS = [...STR_SPLITTERS, " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {
@@ -132,7 +133,7 @@ export function kebabCase<
   Joiner extends string,
 >(str?: T, joiner?: Joiner) {
   return str
-    ? ((Array.isArray(str) ? str : splitByCase(str as string))
+    ? ((Array.isArray(str) ? str : splitByCase(str as string, KEBAB_SPLITTERS))
         .map((p) => p.toLowerCase())
         .join(joiner ?? "-") as KebabCase<T, Joiner>)
     : "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,10 +185,12 @@ export function titleCase<
   T extends string | readonly string[],
   UserCaseOptions extends CaseOptions = CaseOptions,
 >(str?: T, opts?: UserCaseOptions) {
-  return (Array.isArray(str) ? str : splitByCase(str as string))
+  return (
+    Array.isArray(str) ? str : splitByCase(str as string, KEBAB_SPLITTERS)
+  )
     .filter(Boolean)
-    .map((p) =>
-      titleCaseExceptions.test(p)
+    .map((p, index) =>
+      index > 0 && titleCaseExceptions.test(p)
         ? p.toLowerCase()
         : upperFirst(opts?.normalize ? p.toLowerCase() : p),
     )

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -141,6 +141,9 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["in world", "In World"],
+    ["and then", "And Then"],
+    ["the lord of the rings", "The Lord of the Rings"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
   });

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -74,6 +74,7 @@ describe("kebabCase", () => {
     ["FooBAR", "foo-bar"],
     ["ALink", "a-link"],
     ["FOO_BAR", "foo-bar"],
+    ["A string with Spaces", "a-string-with-spaces"],
   ])("%s => %s", (input, expected) => {
     expect(kebabCase(input)).toMatchObject(expected);
   });


### PR DESCRIPTION
## Summary

- Always capitalize the first word in `titleCase`, even when it is a title-case exception (e.g. `in`, `the`, `and`)
- Split input on spaces in addition to case/separator boundaries so lowercase phrases like `in world` are handled correctly

Closes #101

## Test plan

- [x] `pnpm test` (79 tests + typecheck)
- [x] Added cases for `in world`, `and then`, and `the lord of the rings`