### PR TITLE
fix(titleCase): split on spaces and capitalize first word

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import type {
 
 const NUMBER_CHAR_RE = /\d/;
 const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const KEBAB_SPLITTERS = [...STR_SPLITTERS, " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {
@@ -184,10 +185,12 @@ export function titleCase<
   T extends string | readonly string[],
   UserCaseOptions extends CaseOptions = CaseOptions,
 >(str?: T, opts?: UserCaseOptions) {
-  return (Array.isArray(str) ? str : splitByCase(str as string))
+  return (
+    Array.isArray(str) ? str : splitByCase(str as string, KEBAB_SPLITTERS)
+  )
     .filter(Boolean)
-    .map((p) =>
-      titleCaseExceptions.test(p)
+    .map((p, index) =>
+      index > 0 && titleCaseExceptions.test(p)
         ? p.toLowerCase()
         : upperFirst(opts?.normalize ? p.toLowerCase() : p),
     )

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,6 +140,11 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    ["in world", "In World"],
+    ["and then", "And Then"],
+    ["the lord of the rings", "The Lord of the Rings"],
+    ["hello, world!", "Hello, World!"],
+    ["is_technical", "Is Technical"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
   });


### PR DESCRIPTION
## Summary

- Split `titleCase` input on spaces (via `KEBAB_SPLITTERS`) so phrases like `hello, world!` and `in world` capitalize each word
- Always capitalize the first word, even when it is a title-case exception (`in`, `and`, `is`, etc.)

Fixes cases from #92 and #101:

| Input | Before | After |
|-------|--------|-------|
| `hello, world!` | `Hello, world!` | `Hello, World!` |
| `is_technical` | `is Technical` | `Is Technical` |
| `in world` | `in World` | `In World` |

Closes #92
Closes #101

## Test plan

- [x] `pnpm test` (80 tests + typecheck)