### PR TITLE
docs: fix trainCase example output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Split string and joins by Train-Case (a.k.a. HTTP-Header-Case) convention:
 
 ```ts
 trainCase("FooBARb");
-// Foo-Ba-Rb
+// Foo-BA-Rb
 ```
 
 **Notice:** If an uppercase letter is followed by other uppercase letters (like `WWWAuthenticate`), they are preserved (=> `WWW-Authenticate`). You can use `{ normalize: true }` for strictly only having the first letter uppercased.


### PR DESCRIPTION
The README example for `trainCase` shows the wrong output:

```ts
trainCase("FooBARb");
// Foo-Ba-Rb
```

The actual return value is `Foo-BA-Rb`. Without `normalize`, an uppercase run is preserved, which is exactly what the note right under the example states ("if an uppercase letter is followed by other uppercase letters they are preserved"), and what the existing `splitByCase("FooBARb")` test (`["Foo", "BA", "Rb"]`) implies. `Foo-Ba-Rb` is the `{ normalize: true }` result, so the example was showing the normalized output for a non-normalized call.

Verified by running the current source:

```
trainCase("FooBARb") => Foo-BA-Rb
```

Docs-only change, no code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the expected output in a code example to match the actual casing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->