### PR TITLE
fix(titleCase): treat whitespace as a word boundary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,8 @@ export function trainCase<
 const titleCaseExceptions =
   /^(a|an|and|as|at|but|by|for|if|in|is|nor|of|on|or|the|to|with)$/i;
 
+const WHITESPACE_RE = /\s+/;
+
 export function titleCase(): "";
 export function titleCase<
   T extends string | readonly string[],
@@ -184,14 +186,21 @@ export function titleCase<
   T extends string | readonly string[],
   UserCaseOptions extends CaseOptions = CaseOptions,
 >(str?: T, opts?: UserCaseOptions) {
-  return (Array.isArray(str) ? str : splitByCase(str as string))
-    .filter(Boolean)
-    .map((p) =>
-      titleCaseExceptions.test(p)
-        ? p.toLowerCase()
-        : upperFirst(opts?.normalize ? p.toLowerCase() : p),
-    )
-    .join(" ") as TrainCase<T, UserCaseOptions["normalize"]>;
+  return (
+    (Array.isArray(str) ? str : splitByCase(str as string))
+      // `splitByCase` does not treat whitespace as a separator, so a word
+      // boundary detected by case alone keeps the space in the previous part
+      // (`"Hello World"` -> `["Hello ", "World"]`). Joining those with `" "`
+      // would add a second space, so split on whitespace as well.
+      .flatMap((p) => p.split(WHITESPACE_RE))
+      .filter(Boolean)
+      .map((p) =>
+        titleCaseExceptions.test(p)
+          ? p.toLowerCase()
+          : upperFirst(opts?.normalize ? p.toLowerCase() : p),
+      )
+      .join(" ") as TrainCase<T, UserCaseOptions["normalize"]>
+  );
 }
 
 export * from "./types";

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -140,8 +140,20 @@ describe("titleCase", () => {
     ["foo", "Foo"],
     ["foo-bar", "Foo Bar"],
     ["this-IS-aTitle", "This is a Title"],
+    // whitespace is a word boundary and must not be duplicated
+    // https://github.com/unjs/scule/issues/96
+    ["Hello World", "Hello World"],
+    ["hello world", "Hello World"],
+    ["Hello  World", "Hello World"],
+    [" hello world ", "Hello World"],
+    ["tale of two cities", "Tale of Two Cities"],
   ])("%s => %s", (input, expected) => {
     expect(titleCase(input)).toMatchObject(expected);
+  });
+
+  test("is idempotent", () => {
+    const input = "hello big world";
+    expect(titleCase(titleCase(input))).toBe(titleCase(input));
   });
 });
 

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -152,8 +152,9 @@ describe("titleCase", () => {
   });
 
   test("is idempotent", () => {
-    const input = "hello big world";
-    expect(titleCase(titleCase(input))).toBe(titleCase(input));
+    // The pre-fix implementation returned "Hello  World" here, so a second pass
+    // is what actually regresses if whitespace stops being a boundary.
+    expect(titleCase(titleCase("Hello World"))).toBe("Hello World");
   });
 });
 


### PR DESCRIPTION
Fixes #96.

### Problem

```ts
titleCase("Hello World")            // "Hello  World"   <- double space
titleCase(titleCase("Hello World")) // "Hello   World"  <- grows each pass
```

### Cause

`splitByCase` only splits on `-`, `_`, `/`, `.` and case transitions — whitespace is not a separator. So in `"Hello World"` the boundary is found by the case rising edge at `W`, and the space stays attached to the previous part:

```ts
splitByCase("Hello World") // ["Hello ", "World"]
```

`titleCase` then joins those with `" "`, producing `"Hello " + " " + "World"`.

### Fix

Split each part on whitespace before capitalizing:

```ts
.flatMap((p) => p.split(WHITESPACE_RE))
.filter(Boolean)
```

The existing `.filter(Boolean)` already drops the empty parts this creates, so leading/trailing/repeated whitespace collapses too. `splitByCase` itself is untouched — its output is part of the public API and other cases (`kebabCase`, `camelCase`, …) do not join with spaces.

### Tests

Added to the `titleCase` table:

| input | output |
|---|---|
| `Hello World` | `Hello World` |
| `hello world` | `Hello World` |
| `Hello  World` | `Hello World` |
| ` hello world ` | `Hello World` |
| `tale of two cities` | `Tale of Two Cities` |

plus an idempotency assertion (`titleCase(titleCase(x)) === titleCase(x)`).

### Validation

- `vitest run --typecheck`: 81/81 passing, no type errors
- `eslint` and `prettier -c src test` clean

Note: `titleCase("a tale of two cities")` still returns `"a Tale of Two Cities"` — the leading-article case is a separate issue (#101) and is intentionally out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title casing for words separated by spaces.
  * Preserved repeated and surrounding whitespace without introducing duplicate spaces.
  * Ensured applying title casing multiple times produces consistent results.

* **Tests**
  * Added coverage for whitespace boundaries, repeated spaces, surrounding spaces, and repeated application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->