### PR TITLE
feat: treat space as word splitter across casing utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types";
 
 const NUMBER_CHAR_RE = /\d/;
-const STR_SPLITTERS = ["-", "_", "/", "."] as const;
+const STR_SPLITTERS = ["-", "_", "/", ".", " "] as const;
 
 export function isUppercase(char = ""): boolean | undefined {
   if (NUMBER_CHAR_RE.test(char)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-type Splitter = "-" | "_" | "/" | ".";
+type Splitter = "-" | "_" | "/" | "." | " ";
 type FirstOfString<S extends string> = S extends `${infer F}${string}`
   ? F
   : never;

--- a/test/scule.test.ts
+++ b/test/scule.test.ts
@@ -25,6 +25,7 @@ describe("splitByCase", () => {
     ["foo123-bar", ["foo123", "bar"]],
     ["FOOBar", ["FOO", "Bar"]],
     ["ALink", ["A", "Link"]],
+    ["A string with Spaces", ["A", "string", "with", "Spaces"]],
     // with custom splitters
     [
       "foo\\Bar.fuzz-FIZz",
@@ -74,6 +75,7 @@ describe("kebabCase", () => {
     ["FooBAR", "foo-bar"],
     ["ALink", "a-link"],
     ["FOO_BAR", "foo-bar"],
+    ["A string with Spaces", "a-string-with-spaces"],
   ])("%s => %s", (input, expected) => {
     expect(kebabCase(input)).toMatchObject(expected);
   });


### PR DESCRIPTION
## Problem

When converting a space-separated string (e.g. `"A string with Spaces"`) using `kebabCase`, `snakeCase`, or `pascalCase`, space characters were not treated as default word splitters. This caused `kebabCase("A string with Spaces")` to produce `"a string with -spaces"` instead of `"a-string-with-spaces"`.

## Solution

- Added `" "` to `STR_SPLITTERS` in `src/index.ts` and the `Splitter` type union in `src/types.ts`.
- Ensures space-separated tokens are cleanly split into individual words across all casing transformations.

## Testing

- Added unit tests in `test/scule.test.ts` for `splitByCase` and `kebabCase` with space-separated input.
- Verified all 77 tests (including typechecks and lint) pass cleanly with 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-based string splitting to recognize spaces as word separators.
  * Updated kebab-case conversion for phrases containing spaces.

* **Tests**
  * Added coverage for splitting and converting multi-word strings separated by spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->