### PR TITLE
fix(types): join TrainCase words with the joiner instead of prefixing it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export function titleCase<
         ? p.toLowerCase()
         : upperFirst(opts?.normalize ? p.toLowerCase() : p),
     )
-    .join(" ") as TrainCase<T, UserCaseOptions["normalize"]>;
+    .join(" ") as TrainCase<T, UserCaseOptions["normalize"], " ">;
 }
 
 export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,17 @@ type CapitalizedWords<
   T extends readonly string[],
   Accumulator extends string = "",
   Normalize extends boolean | undefined = false,
+  Joiner extends string = "",
 > = T extends readonly [infer F extends string, ...infer R extends string[]]
   ? CapitalizedWords<
       R,
-      `${Accumulator}${Capitalize<Normalize extends true ? Lowercase<F> : F>}`,
-      Normalize
+      F extends ""
+        ? Accumulator
+        : `${Accumulator}${Accumulator extends "" ? "" : Joiner}${Capitalize<
+            Normalize extends true ? Lowercase<F> : F
+          >}`,
+      Normalize,
+      Joiner
     >
   : Accumulator;
 type JoinLowercaseWords<
@@ -155,10 +161,10 @@ export type TrainCase<
     ? string
     : T extends string
       ? SplitByCase<T> extends readonly string[]
-        ? CapitalizedWords<SplitByCase<T>, Joiner>
+        ? CapitalizedWords<SplitByCase<T>, "", Normalize, Joiner>
         : never
       : T extends readonly string[]
-        ? CapitalizedWords<T, Joiner, Normalize>
+        ? CapitalizedWords<T, "", Normalize, Joiner>
         : never;
 
 export type FlatCase<

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -4,7 +4,9 @@ import type {
   PascalCase,
   CamelCase,
   JoinByCase,
+  TrainCase,
 } from "../src/types";
+import { trainCase, titleCase } from "../src";
 
 describe("SplitByCase", () => {
   test("types", () => {
@@ -76,6 +78,39 @@ describe("CamelCase", () => {
 
   test("array", () => {
     assertType<CamelCase<["Foo", "Bar"], true>>("fooBar");
+  });
+});
+
+describe("TrainCase", () => {
+  test("types", () => {
+    expectTypeOf<TrainCase<string>>().toEqualTypeOf<string>();
+    expectTypeOf<TrainCase<string[]>>().toEqualTypeOf<string>();
+  });
+
+  test("string", () => {
+    assertType<TrainCase<"">>("");
+    assertType<TrainCase<"foo">>("Foo");
+    assertType<TrainCase<"fooBar">>("Foo-Bar");
+    assertType<TrainCase<"foo_bar-baz/qux">>("Foo-Bar-Baz-Qux");
+    assertType<TrainCase<"foo--bar-Baz">>("Foo-Bar-Baz");
+    assertType<TrainCase<"FOO_BAR", true>>("Foo-Bar");
+  });
+
+  test("array", () => {
+    assertType<TrainCase<["foo", "Bar"]>>("Foo-Bar");
+  });
+
+  test("custom joiner", () => {
+    assertType<TrainCase<"fooBar", false, " ">>("Foo Bar");
+  });
+
+  test("matches runtime", () => {
+    expectTypeOf(trainCase("fooBar")).toEqualTypeOf<"Foo-Bar">();
+    expectTypeOf(trainCase("foo--bar-Baz")).toEqualTypeOf<"Foo-Bar-Baz">();
+    expectTypeOf(
+      trainCase("FOO_BAR", { normalize: true }),
+    ).toEqualTypeOf<"Foo-Bar">();
+    expectTypeOf(titleCase("fooBar")).toEqualTypeOf<"Foo Bar">();
   });
 });
 


### PR DESCRIPTION
Both `trainCase()` and `titleCase()` return the wrong string literal type. The values are right at runtime; only the types are wrong.

```ts
import { trainCase, titleCase } from "scule";

const a = trainCase("fooBar");  // runtime "Foo-Bar", type "-FooBar"
const b = titleCase("fooBar");  // runtime "Foo Bar", type " FooBar"
```

## Cause

`CapitalizedWords` takes the **accumulator** as its second type parameter, but `TrainCase` passes the **joiner** there:

```ts
? CapitalizedWords<SplitByCase<T>, Joiner>          // string branch
: CapitalizedWords<T, Joiner, Normalize>            // array branch
```

So the joiner seeds the accumulator, lands once at the front, and never appears between words. Two smaller issues fall out of the same lines:

- The string branch passes no `Normalize` argument at all, so `TrainCase<"FOO_BAR", true>` was not normalized.
- `splitByCase` emits empty segments for repeated separators (`"foo--bar"` → `["foo", "", "bar"]`), which would yield a doubled joiner once one was actually inserted.

## Fix

`CapitalizedWords` gains an explicit `Joiner` parameter, inserts it only *between* words, and skips empty segments. `TrainCase` passes the accumulator, `Normalize`, and `Joiner` in the right slots. `titleCase`'s return cast also now forwards its `" "` joiner, which its overload signature already declared.

```ts
TrainCase<"fooBar">          // "Foo-Bar"
TrainCase<"foo--bar-Baz">    // "Foo-Bar-Baz"
TrainCase<"FOO_BAR", true>   // "Foo-Bar"
TrainCase<"fooBar", false, " ">  // "Foo Bar"
```

## Validation

Added a `TrainCase` block to `test/types.test-d.ts`, including assertions that the declared types equal what `trainCase`/`titleCase` actually return. Those tests produce 4 type errors on `main` and pass with this change.

`pnpm test` (lint + `vitest run --typecheck --coverage`) passes: 80 tests, no type errors. No runtime code changed, so the existing 63 runtime tests are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type accuracy for `titleCase` and `trainCase`, including custom separators and normalization options.
  * Empty inputs are now handled more consistently in type-level case conversion.

* **Tests**
  * Added coverage for string and array inputs, custom separators, normalization, and consistency between runtime results and TypeScript types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->